### PR TITLE
評価結果のスキーマ定義とexamplesの追加

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,72 @@
+# Examples
+
+このディレクトリには、soramimi-phonetic-search-datasetの使用例が含まれています。
+
+## basic_usage.py
+
+基本的な使用例を示すスクリプトです。以下の機能を含みます：
+
+- 各種ランキング関数（kanasim, vowel_consonant, phoneme, mora）の評価
+- LLMを使用したリランキング
+- 評価結果のJSON形式での保存
+
+### 使用方法
+
+```bash
+# 基本的な使用方法（母音子音編集距離を使用）
+python examples/basic_usage.py
+
+# 異なるランキング関数を使用
+python examples/basic_usage.py -r kanasim
+python examples/basic_usage.py -r phoneme
+python examples/basic_usage.py -r mora
+
+# 母音の重みを変更（kanasim, vowel_consonantの場合のみ有効）
+python examples/basic_usage.py -r vowel_consonant -vr 0.7
+
+# LLMによるリランキングを使用
+python examples/basic_usage.py --rerank --rerank_model_name gpt-4o-mini
+
+# 評価結果の保存先を指定
+python examples/basic_usage.py -o output.json
+
+# 評価結果を保存しない
+python examples/basic_usage.py --no_save
+```
+
+### オプション
+
+- `-r`, `--rank_func`: ランキング関数の種類（kanasim, vowel_consonant, phoneme, mora）
+- `-n`, `--topn`: 評価に使用する上位n件
+- `-vr`, `--vowel_ratio`: 母音の重み（kanasim, vowel_consonantの場合のみ使用）
+- `--rerank`: LLMによるリランキングを使用
+- `--rerank_input_size`: リランクに使用する候補数
+- `--rerank_batch_size`: リランクのバッチサイズ
+- `--rerank_model_name`: リランクに使用するモデル名
+- `--rerank_interval`: リランクのインターバル（秒）
+- `-o`, `--output_file_path`: 出力ファイルのパス
+- `--no_save`: 評価結果を保存しない
+
+## 実行方法
+
+1. まず、プロジェクトのルートディレクトリで以下のコマンドを実行してパッケージをインストールします：
+
+```bash
+pip install -e .
+```
+
+2. サンプルコードを実行：
+
+```bash
+# 基本的な使用例
+python examples/basic_usage.py
+
+# パラメータをカスタマイズした例
+python examples/basic_usage.py -r vowel_consonant -vr 0.7 -n 5
+```
+
+## 注意事項
+
+- サンプルコードを実行する前に、必要なパッケージがすべてインストールされていることを確認してください。
+- 各ランキング関数のパラメータは必要に応じて調整できます。
+- 評価には`baseball.json`データセットが使用されます。 

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,220 @@
+import argparse
+import json
+from typing import Callable
+
+from soramimi_phonetic_search_dataset import (
+    evaluate_ranking_function_with_details,
+    rank_by_kanasim,
+    rank_by_mora_editdistance,
+    rank_by_phoneme_editdistance,
+    rank_by_vowel_consonant_editdistance,
+)
+from soramimi_phonetic_search_dataset.reranker import rerank_by_llm
+
+
+def create_reranking_function(
+    base_rank_func: Callable[[list[str], list[str]], list[list[str]]],
+    rerank_input_size: int,
+    rerank_model_name: str,
+    rerank_batch_size: int,
+    rerank_interval: int,
+    topn: int,
+    **base_rank_kwargs,
+) -> Callable[[list[str], list[str]], list[list[str]]]:
+    """
+    ベースのランキング関数とLLMによるリランクを組み合わせた関数を作成する
+
+    Args:
+        base_rank_func: ベースのランキング関数
+        rerank_input_size: リランクに使用する候補数
+        rerank_model_name: リランクに使用するモデル名
+        rerank_batch_size: リランクのバッチサイズ
+        rerank_interval: リランクのインターバル
+        topn: 最終的な出力数
+        **base_rank_kwargs: ベースのランキング関数に渡す追加の引数
+
+    Returns:
+        組み合わせたランキング関数
+    """
+
+    def combined_rank_func(
+        query_texts: list[str], wordlist_texts: list[str]
+    ) -> list[list[str]]:
+        # ベースのランキングを実行
+        base_ranked_wordlists = base_rank_func(
+            query_texts, wordlist_texts, **base_rank_kwargs
+        )
+
+        # 上位N件を取得してリランク
+        topk_ranked_wordlists = [
+            wordlist[:rerank_input_size] for wordlist in base_ranked_wordlists
+        ]
+        reranked_wordlists = rerank_by_llm(
+            query_texts,
+            topk_ranked_wordlists,
+            topn=topn,
+            model_name=rerank_model_name,
+            batch_size=rerank_batch_size,
+            rerank_interval=rerank_interval,
+        )
+        return reranked_wordlists
+
+    return combined_rank_func
+
+
+def get_default_output_path(
+    rank_func: str,
+    topn: int,
+    rerank: bool = False,
+    rerank_topn: int = 10,
+    rerank_model_name: str = "gpt-4o-mini",
+) -> str:
+    suffix = f"_{rank_func}_top{topn}"
+    if rerank:
+        suffix += f"_reranked_top{rerank_topn}_model{rerank_model_name}"
+    return f"output{suffix}.json"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate phonetic search dataset.")
+    parser.add_argument(
+        "-r",
+        "--rank_func",
+        type=str,
+        choices=["kanasim", "vowel_consonant", "phoneme", "mora"],
+        default="vowel_consonant",
+        help="Rank function: kanasim, vowel_consonant, phoneme, mora",
+    )
+    parser.add_argument(
+        "-n",
+        "--topn",
+        type=int,
+        default=10,
+        help="Top N",
+    )
+    parser.add_argument(
+        "-vr",
+        "--vowel_ratio",
+        type=float,
+        default=0.5,
+        help="Vowel ratio, which is used only when rank_func is vowel_consonant",
+    )
+    parser.add_argument(
+        "--rerank",
+        action="store_true",
+        help="Rerank the wordlists by LLM",
+    )
+    parser.add_argument(
+        "--rerank_input_size",
+        type=int,
+        default=100,
+        help="Number of top candidates to consider for reranking",
+    )
+    parser.add_argument(
+        "--rerank_batch_size",
+        type=int,
+        default=10,
+        help="Batch size for reranking",
+    )
+    parser.add_argument(
+        "--rerank_model_name",
+        type=str,
+        default="gpt-4o-mini",
+        help="Model name for reranking",
+    )
+    parser.add_argument(
+        "--rerank_interval",
+        type=int,
+        default=0,
+        help="Sleep interval in seconds between reranking batches",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_file_path",
+        type=str,
+        help="Path to the output CSV file",
+    )
+    parser.add_argument(
+        "--no_save",
+        action="store_true",
+        help="Do not save results to file",
+    )
+    args = parser.parse_args()
+
+    # ベースのランキング関数を選択
+    if args.rank_func == "kanasim":
+        base_rank_func = rank_by_kanasim
+        rank_kwargs = {"vowel_ratio": args.vowel_ratio}
+    elif args.rank_func == "mora":
+        base_rank_func = rank_by_mora_editdistance
+        rank_kwargs = {}
+    elif args.rank_func == "vowel_consonant":
+        base_rank_func = rank_by_vowel_consonant_editdistance
+        rank_kwargs = {"vowel_ratio": args.vowel_ratio}
+    elif args.rank_func == "phoneme":
+        base_rank_func = rank_by_phoneme_editdistance
+        rank_kwargs = {}
+
+    # リランクが必要な場合は組み合わせた関数を作成
+    if args.rerank:
+        _rank_func = create_reranking_function(
+            base_rank_func=base_rank_func,
+            rerank_input_size=args.rerank_input_size,
+            rerank_model_name=args.rerank_model_name,
+            rerank_batch_size=args.rerank_batch_size,
+            rerank_interval=args.rerank_interval,
+            topn=args.topn,
+            **rank_kwargs,
+        )
+
+        # 警告を回避するためdefでラップ
+        def rank_func(q, w):
+            return _rank_func(q, w)
+    else:
+        # 警告を回避するためdefでラップ
+        def rank_func(q, w):
+            return base_rank_func(q, w, **rank_kwargs)
+
+    # 評価を実行
+    results = evaluate_ranking_function_with_details(
+        ranking_func=rank_func,
+        topn=args.topn,
+    )
+
+    # パラメータを設定
+    results.parameters.rank_func = args.rank_func
+    results.parameters.vowel_ratio = (
+        args.vowel_ratio if args.rank_func in ["kanasim", "vowel_consonant"] else None
+    )
+    results.parameters.rerank = args.rerank
+    results.parameters.rerank_model_name = (
+        args.rerank_model_name if args.rerank else None
+    )
+    results.parameters.rerank_input_size = (
+        args.rerank_input_size if args.rerank else None
+    )
+
+    print("Recall: ", results.metrics.recall)
+
+    if args.output_file_path:
+        output_path = args.output_file_path
+    else:
+        output_path = get_default_output_path(
+            args.rank_func,
+            args.topn,
+            args.rerank,
+            args.rerank_input_size,
+            args.rerank_model_name,
+        )
+
+    if not args.no_save:
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(
+                results, f, ensure_ascii=False, indent=2, default=lambda x: x.__dict__
+            )
+
+
+if __name__ == "__main__":
+    main()
+    main()
+    main()

--- a/src/soramimi_phonetic_search_dataset/__init__.py
+++ b/src/soramimi_phonetic_search_dataset/__init__.py
@@ -1,4 +1,8 @@
-from .evaluate import evaluate_ranking_function
+"""
+Soramimi Phonetic Search Dataset package
+"""
+
+from .evaluate import evaluate_ranking_function, evaluate_ranking_function_with_details
 from .ranking import (
     rank_by_kanasim,
     rank_by_mora_editdistance,
@@ -9,6 +13,7 @@ from .schemas import PhoneticSearchDataset, PhoneticSearchQuery
 
 __all__ = [
     "evaluate_ranking_function",
+    "evaluate_ranking_function_with_details",
     "rank_by_mora_editdistance",
     "rank_by_vowel_consonant_editdistance",
     "rank_by_phoneme_editdistance",
@@ -16,7 +21,3 @@ __all__ = [
     "PhoneticSearchDataset",
     "PhoneticSearchQuery",
 ]
-
-
-def hello() -> str:
-    return "Hello from soramimi-phonetic-search-dataset!"

--- a/src/soramimi_phonetic_search_dataset/reranker.py
+++ b/src/soramimi_phonetic_search_dataset/reranker.py
@@ -1,0 +1,115 @@
+import time
+from typing import Any, Type
+
+from litellm import batch_completion
+from pydantic import BaseModel
+from tqdm import tqdm
+
+
+def get_structured_outputs(
+    model_name: str,
+    messages: list[list[dict[str, Any]]],
+    response_format: Type[BaseModel],
+    temperature: float = 0.0,
+    max_tokens: int = 1000,
+) -> list[BaseModel]:
+    raw_responses = batch_completion(
+        model=model_name,
+        messages=messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        response_format=response_format,
+    )
+    return [
+        response_format.model_validate_json(response.choices[0].message.content)
+        for response in raw_responses
+    ]
+
+
+def rerank_by_llm(
+    query_texts: list[str],
+    wordlist_texts: list[list[str]],
+    *,
+    topn: int = 10,
+    model_name: str = "gpt-4o-mini",
+    batch_size: int = 10,
+    temperature: float = 0.0,
+    rerank_interval: int = 60,
+) -> list[list[str]]:
+    class RerankedWordlist(BaseModel):
+        reranked: list[int]
+
+    prompt = """
+    You are a phonetic search assistant.
+    You are given a query and a list of words.
+    You need to rerank the words based on phonetic similarity to the query.
+    When estimating phonetic similarity, please consider the following:
+    1. Prioritize matching vowels
+    2. Substitution, insertion, or deletion of nasal sounds, geminate consonants, and long vowels is acceptable
+    3. For other cases, words with similar mora counts are preferred
+    You need to return only the reranked list of index numbers of the words, no other text.
+    You need to return only topn index numbers.
+
+    Example:
+    Query: タロウ
+    Wordlist: 
+    0. アオ
+    1. アオウヅ
+    2. アノウ
+    3. タキョウ
+    4. タド
+    5. タノ
+    6. タロウ
+    7. タンノ
+    Top N: 5
+    Reranked: 6, 4, 5, 7, 2
+    """
+
+    user_prompt = """
+    Query: {query}
+    Wordlist:
+    {wordlist}
+    Top N: {topn}
+    Reranked:
+    """
+
+    messages = []
+    for query, wordlist in zip(query_texts, wordlist_texts):
+        wordlist_str = "\n".join([f"{i}. {word}" for i, word in enumerate(wordlist)])
+        message = []
+        message.append({"role": "system", "content": prompt})
+        message.append(
+            {
+                "role": "user",
+                "content": user_prompt.format(
+                    query=query, wordlist=wordlist_str, topn=topn
+                ),
+            }
+        )
+        messages.append(message)
+
+    reranked_wordlists = []
+    for i in tqdm(range(0, len(messages), batch_size)):
+        batch_messages = messages[i : i + batch_size]
+        responses = get_structured_outputs(
+            model_name=model_name,
+            messages=batch_messages,
+            temperature=temperature,
+            max_tokens=1000,
+            response_format=RerankedWordlist,
+        )
+        for wordlist, response in zip(wordlist_texts[i : i + batch_size], responses):
+            reranked_wordlist = []
+
+            response_typed = RerankedWordlist.model_validate(response)
+            for i in response_typed.reranked:
+                if 0 <= i < len(wordlist):
+                    reranked_wordlist.append(wordlist[i])
+                else:
+                    reranked_wordlist.append("NA")
+            reranked_wordlists.append(reranked_wordlist)
+
+        time.sleep(rerank_interval)
+
+    return reranked_wordlists
+    return reranked_wordlists

--- a/src/soramimi_phonetic_search_dataset/schemas.py
+++ b/src/soramimi_phonetic_search_dataset/schemas.py
@@ -20,3 +20,41 @@ class PhoneticSearchDataset:
         words = data["words"]
         metadata = data.get("metadata", {})
         return cls(queries=queries, words=words, metadata=metadata)
+
+
+@dataclass
+class PhoneticSearchResult:
+    query: str
+    ranked_words: list[str]
+    positive_words: list[str]
+
+
+@dataclass
+class PhoneticSearchMetrics:
+    recall: float
+
+
+@dataclass
+class PhoneticSearchParameters:
+    topn: int
+    rank_func: str
+    vowel_ratio: float | None = None
+    rerank: bool = False
+    rerank_model_name: str | None = None
+    rerank_input_size: int | None = None
+
+
+@dataclass
+class PhoneticSearchResults:
+    parameters: PhoneticSearchParameters
+    metrics: PhoneticSearchMetrics
+    results: list[PhoneticSearchResult]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PhoneticSearchResults":
+        results = [PhoneticSearchResult(**result) for result in data["results"]]
+        return cls(
+            parameters=PhoneticSearchParameters(**data["parameters"]),
+            metrics=PhoneticSearchMetrics(**data["metrics"]),
+            results=results,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "soramimi-phonetic-search-dataset"
-version = "0.1.dev10+g3922abe.d20250308"
+version = "0.1.dev16+gbfc0f89.d20250309"
 source = { editable = "." }
 dependencies = [
     { name = "editdistance" },


### PR DESCRIPTION
feat: 評価結果のスキーマ定義とexamplesの追加

# 変更内容
- PhoneticSearchMetrics, PhoneticSearchParameters, PhoneticSearchResult, PhoneticSearchResultsのデータクラスを追加
- evaluate_ranking_functionをevaluate_ranking_function_with_detailsに改名し、詳細な結果を返すように変更
- evaluate_ranking_functionは従来通りrecallのみを返すように維持
- basic_usage.pyとexamples/README.mdを追加
- LLMによるリランク機能を追加（reranker.py）

# 動作確認方法
```bash
# 基本的な使用方法
python examples/basic_usage.py

# リランク機能を使用
python examples/basic_usage.py --rerank
```
