### PR TITLE
docs: add LLM reranking results to leaderboard

### DIFF
--- a/leaderboard.md
+++ b/leaderboard.md
@@ -8,10 +8,14 @@
 | Phoneme EditDistance | 0.672 |
 | Vowel Consonant EditDistance | 0.744 |
 | KanaSim EditDistance | 0.831 |
+| LLM Rerank (gpt-4o-mini) | 0.642 |
+| LLM Rerank (gpt-4o) | 0.595 |
+| LLM Rerank (gemini-2.0-flash) | 0.565 |
 
 ## 評価方法
 - 各手法について、トップ10件の検索結果に対するリコール値を計算
 - データセット: soramimi-phonetic-search-dataset v0.0.3
 - パラメータ設定:
   - Vowel Consonant EditDistance: vowel_ratio=0.8
-  - KanaSim EditDistance: vowel_ratio=0.8 
+  - KanaSim EditDistance: vowel_ratio=0.8
+  - LLM Rerank: Vowel Consonant EditDistance (vowel_ratio=0.5) でtop100を取得（recall@100=0.861）した結果からtop10を再ランク付け 


### PR DESCRIPTION
# LLMリランキング結果の追加

## 変更内容
- leaderboardにLLMリランキング手法の評価結果を追加
  - gpt-4o-mini (Recall@10: 0.642)
  - gpt-4o (Recall@10: 0.595)
  - gemini-2.0-flash (Recall@10: 0.565)
- リランキング手法のパラメータ設定を追加
