### PR TITLE
リーダーボードとベーシック使用例の更新

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -49,6 +49,10 @@ def create_reranking_function(
         topk_ranked_wordlists = [
             wordlist[:rerank_input_size] for wordlist in base_ranked_wordlists
         ]
+        # あいうえお順に並べ替え
+        # topk_ranked_wordlists = [
+        #    sorted(wordlist, key=lambda x: x[0]) for wordlist in topk_ranked_wordlists
+        # ]
         reranked_wordlists = rerank_by_llm(
             query_texts,
             topk_ranked_wordlists,
@@ -71,7 +75,9 @@ def get_default_output_path(
 ) -> str:
     suffix = f"_{rank_func}_top{topn}"
     if rerank:
-        suffix += f"_reranked_top{rerank_topn}_model{rerank_model_name}"
+        # スラッシュを含む場合はハイフンに変換
+        model_name_safe = rerank_model_name.replace("/", "-")
+        suffix += f"_reranked_top{rerank_topn}_model{model_name_safe}"
     return f"output{suffix}.json"
 
 

--- a/leaderboard.md
+++ b/leaderboard.md
@@ -11,6 +11,7 @@
 | LLM Rerank (gpt-4o-mini) | 0.642 |
 | LLM Rerank (gpt-4o) | 0.595 |
 | LLM Rerank (gemini-2.0-flash) | 0.565 |
+| LLM Rerank (gpt-4.5-preview) | 0.614 |
 
 ## 評価方法
 - 各手法について、トップ10件の検索結果に対するリコール値を計算

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "soramimi-phonetic-search-dataset"
-version = "0.0.4.dev2+g952d7eb.d20250309"
+version = "0.0.4.dev6+ga9f9c39.d20250310"
 source = { editable = "." }
 dependencies = [
     { name = "editdistance" },


### PR DESCRIPTION
# リーダーボードとベーシック使用例の更新

## 変更内容
- リーダーボードにGPT-4.5-previewの結果を追加
- basic_usage.pyのあいうえお順ソートをコメントアウト
- 依存関係の更新
