### PR TITLE
feat: mainブランチへのプッシュ時にupdate-versionワークフローを実行するように変更

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -17,6 +17,9 @@ on:
         required: false
         default: false
         type: boolean
+  push:
+    branches:
+      - main
 
 env:
   TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}


### PR DESCRIPTION
# mainブランチへのプッシュ時にupdate-versionワークフローを実行するように変更

## 内容
- update-versionワークフローにpushトリガーを追加
- mainブランチへのプッシュ時にワークフローが実行されるように設定
