### PR TITLE
feat: バージョン更新ワークフローを分割し、Pythonファイル変更時のみ自動更新するように変更

### DIFF
--- a/.github/workflows/auto-update-version.yaml
+++ b/.github/workflows/auto-update-version.yaml
@@ -1,0 +1,23 @@
+name: Auto Update Version
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.py'
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Fetch Tags
+      run: git fetch --tags
+
+    - name: Update Version
+      run: |
+        # パッチバージョンを1つ上げる
+        bash .github/scripts/update_version.sh -i patch 

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -17,15 +17,9 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches:
-      - main
-
-env:
-  TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
 
 jobs:
-  publish:
+  update-version:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# バージョン更新ワークフローの改善

## 内容
- バージョン更新ワークフローを手動実行用と自動実行用に分割
- 自動更新はPythonファイル（.py）の変更時のみ実行されるように変更
- 手動実行用ワークフローから不要な設定を削除
