### PR TITLE
feat: デフォルトのデータセットを読み込む関数を追加

### DIFF
--- a/src/soramimi_phonetic_search_dataset/__init__.py
+++ b/src/soramimi_phonetic_search_dataset/__init__.py
@@ -2,6 +2,11 @@
 Soramimi Phonetic Search Dataset package
 """
 
+from .dataset import (
+    DEFAULT_DATASET_PATH,
+    load_default_dataset,
+    load_phonetic_search_dataset,
+)
 from .evaluate import evaluate_ranking_function, evaluate_ranking_function_with_details
 from .ranking import (
     rank_by_kanasim,
@@ -20,4 +25,7 @@ __all__ = [
     "rank_by_kanasim",
     "PhoneticSearchDataset",
     "PhoneticSearchQuery",
+    "load_phonetic_search_dataset",
+    "load_default_dataset",
+    "DEFAULT_DATASET_PATH",
 ]

--- a/src/soramimi_phonetic_search_dataset/dataset.py
+++ b/src/soramimi_phonetic_search_dataset/dataset.py
@@ -1,0 +1,22 @@
+"""
+データセット関連の処理を提供するモジュール
+"""
+
+import json
+from pathlib import Path
+
+from .schemas import PhoneticSearchDataset
+
+DEFAULT_DATASET_PATH = Path(__file__).parent / "data" / "baseball.json"
+
+
+def load_phonetic_search_dataset(path: str) -> PhoneticSearchDataset:
+    """データセットを読み込む"""
+    with open(path, "r") as f:
+        dataset = json.load(f)
+    return PhoneticSearchDataset.from_dict(dataset)
+
+
+def load_default_dataset() -> PhoneticSearchDataset:
+    """デフォルトのデータセットを読み込む"""
+    return load_phonetic_search_dataset(str(DEFAULT_DATASET_PATH))

--- a/src/soramimi_phonetic_search_dataset/evaluate.py
+++ b/src/soramimi_phonetic_search_dataset/evaluate.py
@@ -1,23 +1,13 @@
-import time  # 追加
-from pathlib import Path
+import time
 from typing import Callable
 
+from soramimi_phonetic_search_dataset.dataset import load_default_dataset
 from soramimi_phonetic_search_dataset.schemas import (
-    PhoneticSearchDataset,
     PhoneticSearchMetrics,
     PhoneticSearchParameters,
     PhoneticSearchResult,
     PhoneticSearchResults,
 )
-
-
-def load_phonetic_search_dataset(path: str) -> PhoneticSearchDataset:
-    """データセットを読み込む"""
-    import json
-
-    with open(path, "r") as f:
-        dataset = json.load(f)
-    return PhoneticSearchDataset.from_dict(dataset)
 
 
 def calculate_recall(
@@ -63,8 +53,7 @@ def evaluate_ranking_function_with_details(
         PhoneticSearchResults: 評価結果
     """
     # デフォルトのデータセットを読み込む
-    dataset_path = Path(__file__).parent / "data" / "baseball.json"
-    dataset = load_phonetic_search_dataset(str(dataset_path))
+    dataset = load_default_dataset()
 
     # クエリと正解を取得
     query_texts = [query.query for query in dataset.queries]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -6,11 +6,9 @@ from soramimi_phonetic_search_dataset import (
     PhoneticSearchDataset,
     PhoneticSearchQuery,
     evaluate_ranking_function,
-)
-from soramimi_phonetic_search_dataset.evaluate import (
-    calculate_recall,
     load_phonetic_search_dataset,
 )
+from soramimi_phonetic_search_dataset.evaluate import calculate_recall
 
 
 @pytest.fixture
@@ -85,7 +83,7 @@ def test_evaluate_ranking_function(monkeypatch, sample_dataset):
         return sample_dataset
 
     monkeypatch.setattr(
-        "soramimi_phonetic_search_dataset.evaluate.load_phonetic_search_dataset",
+        "soramimi_phonetic_search_dataset.dataset.load_phonetic_search_dataset",
         mock_load_dataset,
     )
 


### PR DESCRIPTION
# デフォルトのデータセットを読み込む関数を追加

## 変更内容
- `dataset.py`に`load_default_dataset`関数を追加
- `__init__.py`で新しい関数を公開
- `evaluate.py`で`load_default_dataset`を使用するように修正

## 使用例
```python
from soramimi_phonetic_search_dataset import load_default_dataset

dataset = load_default_dataset()
```
