### PR TITLE
011_03 の gpt-5.1 medium step-by-step スクリプトを追加

### DIFF
--- a/reproduce_leaderboard/README.md
+++ b/reproduce_leaderboard/README.md
@@ -46,6 +46,7 @@ uv run methods/008_03_llm_rerank_gpt54_step_by_step.py  # LLMリランク (gpt-5
 uv run methods/010_01_llm_rerank_gpt54_medium_simple.py  # LLMリランク (gpt-5.4, reasoning medium, prompt 010_01 simple)
 uv run methods/010_02_llm_rerank_gpt54_medium_detailed.py  # LLMリランク (gpt-5.4, reasoning medium, prompt 010_02 detailed)
 uv run methods/010_03_llm_rerank_gpt54_medium_step_by_step.py  # LLMリランク (gpt-5.4, reasoning medium, prompt 010_03 step-by-step)
+uv run methods/011_03_llm_rerank_gpt51_medium_step_by_step.py  # LLMリランク (gpt-5.1, reasoning medium, prompt 011_03 step-by-step)
 ```
 
 ### カスタム評価の実行
@@ -115,7 +116,8 @@ results/
 ├── 010_01_llm_rerank_gpt54_medium_simple_cost_estimate.json
 ├── 010_02_llm_rerank_gpt54_medium_detailed.json
 ├── 010_03_llm_rerank_gpt54_medium_step_by_step.json
-└── 010_03_llm_rerank_gpt54_medium_step_by_step_cost_estimate.json
+├── 010_03_llm_rerank_gpt54_medium_step_by_step_cost_estimate.json
+└── 011_03_llm_rerank_gpt51_medium_step_by_step.json
 ```
 
 `*_cost_estimate.json` は、先頭10件で計測した token/cost を全150件へ線形外挿した**試算**です。full run の実測値ではありません。
@@ -125,7 +127,7 @@ results/
 - 評価には`baseball.json`データセットが使用されます。
 - 各ランキング関数のパラメータは必要に応じて調整できます。
 - LLMリランクを使用する場合は、以下の環境変数を設定してください：
-  - OpenAI API（gpt-4o-mini, gpt-4o, gpt-4.5-preview, gpt-5.4）を使用する場合：
+  - OpenAI API（gpt-4o-mini, gpt-4o, gpt-4.5-preview, gpt-5.4, gpt-5.1）を使用する場合：
     - `OPENAI_API_KEY`: OpenAIのAPIキー
   - Gemini API（gemini-2.0-flash）を使用する場合：
     - `GEMINI_API_KEY`: Google Cloud PlatformのAPIキー

--- a/reproduce_leaderboard/methods/011_03_llm_rerank_gpt51_medium_step_by_step.py
+++ b/reproduce_leaderboard/methods/011_03_llm_rerank_gpt51_medium_step_by_step.py
@@ -1,0 +1,45 @@
+"""
+LLMリランク (gpt-5.1, reasoning effort medium, step-by-step prompt) による評価を実行するスクリプト
+"""
+
+import subprocess
+from pathlib import Path
+
+
+def main():
+    output_dir = Path(__file__).parent.parent / "results"
+    output_dir.mkdir(exist_ok=True)
+    output_path = output_dir / "011_03_llm_rerank_gpt51_medium_step_by_step.json"
+
+    evaluate_script = Path(__file__).parent / "common" / "evaluate_ranking.py"
+    cmd = [
+        "uv",
+        "run",
+        str(evaluate_script),
+        "--rank_func",
+        "vowel_consonant",
+        "--topn",
+        "10",
+        "--vowel_ratio",
+        "0.5",
+        "--rerank",
+        "--rerank_input_size",
+        "100",
+        "--rerank_interval",
+        "0",
+        "--rerank_batch_size",
+        "10",
+        "--rerank_model_name",
+        "gpt-5.1",
+        "--rerank_reasoning_effort",
+        "medium",
+        "--rerank_prompt_template",
+        "008_03_step_by_step",
+        "--output_file_path",
+        str(output_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/reproduce_leaderboard/run_all.sh
+++ b/reproduce_leaderboard/run_all.sh
@@ -47,4 +47,7 @@ uv run methods/010_02_llm_rerank_gpt54_medium_detailed.py
 echo "=== LLM Rerank (gpt-5.4, reasoning medium, prompt 010_03 step-by-step) ==="
 uv run methods/010_03_llm_rerank_gpt54_medium_step_by_step.py
 
+echo "=== LLM Rerank (gpt-5.1, reasoning medium, prompt 011_03 step-by-step) ==="
+uv run methods/011_03_llm_rerank_gpt51_medium_step_by_step.py
+
 echo "Done!"


### PR DESCRIPTION
## 概要
- gpt-5.1 / reasoning effort medium / step-by-step prompt で 011_03 を出力する再現スクリプトを追加
- run_all.sh から 011_03 を実行できるよう更新
- README に個別実行例と出力先を追記

## 補足
- 実験本体は実行していないため、結果 JSON や leaderboard の Recall は未更新です。
- 011_03 は 010_03 / 008_03 と同じ step-by-step prompt (008_03_step_by_step) を使います。