### PR TITLE
10件の小データセットで評価できるようにする

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -31,6 +31,25 @@ recall = evaluate_ranking_function(ranking_func=my_ranking_function, topn=10)
 print(f"Recall@10: {recall}")
 ```
 
+If you want a cheaper LLM smoke test, you can use the bundled small dataset, which keeps the original word list and limits evaluation to the first 10 queries.
+
+```python
+from soramimi_phonetic_search_dataset import (
+    evaluate_ranking_function,
+    load_small_dataset,
+)
+
+small_dataset = load_small_dataset()
+recall = evaluate_ranking_function(
+    ranking_func=my_ranking_function,
+    topn=10,
+    dataset=small_dataset,
+)
+print(f"Recall@10 on small dataset: {recall}")
+```
+
+The sample script in this repository also supports `--dataset_size small`.
+
 ### Sample Ranking Functions
 
 The following ranking functions are provided:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ recall = evaluate_ranking_function(ranking_func=my_ranking_function, topn=10)
 print(f"Recall@10: {recall}")
 ```
 
+LLMでの試行回数を減らしたい場合は、先頭10件のクエリだけを使う小データセットも利用できます。
+
+```python
+from soramimi_phonetic_search_dataset import (
+    evaluate_ranking_function,
+    load_small_dataset,
+)
+
+small_dataset = load_small_dataset()
+recall = evaluate_ranking_function(
+    ranking_func=my_ranking_function,
+    topn=10,
+    dataset=small_dataset,
+)
+print(f"Recall@10 on small dataset: {recall}")
+```
+
+リポジトリ内のサンプルスクリプトでも `--dataset_size small` を指定すると、同じ10件版で評価できます。
+
 ### サンプルのランキング関数
 
 以下のランキング関数が実装済みです：

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -5,6 +5,8 @@ from typing import Callable
 from reproduce_leaderboard.methods.common.reranker import rerank_by_llm
 from soramimi_phonetic_search_dataset import (
     evaluate_ranking_function_with_details,
+    load_default_dataset,
+    load_small_dataset,
     rank_by_kanasim,
     rank_by_mora_editdistance,
     rank_by_phoneme_editdistance,
@@ -72,6 +74,7 @@ def create_reranking_function(
 def get_default_output_path(
     rank_func: str,
     topn: int,
+    dataset_size: str = "default",
     rerank: bool = False,
     rerank_topn: int = 10,
     rerank_model_name: str = "gpt-4o-mini",
@@ -84,6 +87,8 @@ def get_default_output_path(
         suffix += f"_reranked_top{rerank_topn}_model{model_name_safe}"
         if rerank_reasoning_effort:
             suffix += f"_reasoning{rerank_reasoning_effort}"
+    if dataset_size != "default":
+        suffix += f"_dataset{dataset_size}"
     return f"output{suffix}.json"
 
 
@@ -110,6 +115,13 @@ def main():
         type=float,
         default=0.5,
         help="Vowel ratio, which is used only when rank_func is vowel_consonant",
+    )
+    parser.add_argument(
+        "--dataset_size",
+        type=str,
+        choices=["default", "small"],
+        default="default",
+        help="Dataset size: default (150 queries) or small (10 queries)",
     )
     parser.add_argument(
         "--rerank",
@@ -194,10 +206,15 @@ def main():
         def rank_func(q, w):
             return base_rank_func(q, w, **rank_kwargs)
 
+    dataset = (
+        load_small_dataset() if args.dataset_size == "small" else load_default_dataset()
+    )
+
     # 評価を実行
     results = evaluate_ranking_function_with_details(
         ranking_func=rank_func,
         topn=args.topn,
+        dataset=dataset,
     )
 
     # パラメータを設定
@@ -224,6 +241,7 @@ def main():
         output_path = get_default_output_path(
             args.rank_func,
             args.topn,
+            args.dataset_size,
             args.rerank,
             args.rerank_input_size,
             args.rerank_model_name,

--- a/reproduce_leaderboard/methods/common/evaluate_ranking.py
+++ b/reproduce_leaderboard/methods/common/evaluate_ranking.py
@@ -7,6 +7,7 @@ from reranker import calculate_token_cost, get_last_token_usage, rerank_by_llm
 from soramimi_phonetic_search_dataset import (
     evaluate_ranking_function_with_details,
     load_default_dataset,
+    load_small_dataset,
     rank_by_kanasim,
     rank_by_mora_editdistance,
     rank_by_phoneme_editdistance,
@@ -91,6 +92,7 @@ def create_reranking_function(
 def get_default_output_path(
     rank_func: str,
     topn: int,
+    dataset_size: str = "default",
     rerank: bool = False,
     rerank_topn: int = 10,
     rerank_model_name: str = "gpt-4o-mini",
@@ -106,6 +108,8 @@ def get_default_output_path(
             suffix += f"_reasoning{rerank_reasoning_effort}"
         if rerank_prompt_template != "default":
             suffix += f"_prompt{rerank_prompt_template}"
+    if dataset_size != "default":
+        suffix += f"_dataset{dataset_size}"
     return f"output{suffix}.json"
 
 
@@ -132,6 +136,13 @@ def main():
         type=float,
         default=0.5,
         help="Vowel ratio, which is used only when rank_func is vowel_consonant",
+    )
+    parser.add_argument(
+        "--dataset_size",
+        type=str,
+        choices=["default", "small"],
+        default="default",
+        help="Dataset size: default (150 queries) or small (10 queries)",
     )
     parser.add_argument(
         "--rerank",
@@ -202,10 +213,12 @@ def main():
         base_rank_func = rank_by_phoneme_editdistance
         rank_kwargs = {}
 
+    dataset = (
+        load_small_dataset() if args.dataset_size == "small" else load_default_dataset()
+    )
+
     # リランクが必要な場合は組み合わせた関数を作成
     if args.rerank:
-        # デフォルトのデータセットを読み込んでpositive_textsを取得
-        dataset = load_default_dataset()
         positive_texts = [query.positive for query in dataset.queries]
 
         _rank_func = create_reranking_function(
@@ -233,6 +246,7 @@ def main():
     results = evaluate_ranking_function_with_details(
         ranking_func=rank_func,
         topn=args.topn,
+        dataset=dataset,
     )
 
     # パラメータを設定
@@ -274,6 +288,7 @@ def main():
         output_path = get_default_output_path(
             args.rank_func,
             args.topn,
+            args.dataset_size,
             args.rerank,
             args.rerank_input_size,
             args.rerank_model_name,

--- a/src/soramimi_phonetic_search_dataset/__init__.py
+++ b/src/soramimi_phonetic_search_dataset/__init__.py
@@ -4,8 +4,10 @@ Soramimi Phonetic Search Dataset package
 
 from .dataset import (
     DEFAULT_DATASET_PATH,
+    SMALL_DATASET_QUERY_COUNT,
     load_default_dataset,
     load_phonetic_search_dataset,
+    load_small_dataset,
 )
 from .evaluate import evaluate_ranking_function, evaluate_ranking_function_with_details
 from .ranking import (
@@ -27,5 +29,7 @@ __all__ = [
     "PhoneticSearchQuery",
     "load_phonetic_search_dataset",
     "load_default_dataset",
+    "load_small_dataset",
     "DEFAULT_DATASET_PATH",
+    "SMALL_DATASET_QUERY_COUNT",
 ]

--- a/src/soramimi_phonetic_search_dataset/dataset.py
+++ b/src/soramimi_phonetic_search_dataset/dataset.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from .schemas import PhoneticSearchDataset
 
 DEFAULT_DATASET_PATH = Path(__file__).parent / "data" / "baseball.json"
+SMALL_DATASET_QUERY_COUNT = 10
 
 
 def load_phonetic_search_dataset(path: str) -> PhoneticSearchDataset:
@@ -17,6 +18,35 @@ def load_phonetic_search_dataset(path: str) -> PhoneticSearchDataset:
     return PhoneticSearchDataset.from_dict(dataset)
 
 
-def load_default_dataset() -> PhoneticSearchDataset:
+def _subset_dataset(
+    dataset: PhoneticSearchDataset, *, query_limit: int
+) -> PhoneticSearchDataset:
+    if query_limit <= 0:
+        raise ValueError("query_limit must be a positive integer")
+    if query_limit >= len(dataset.queries):
+        return dataset
+
+    metadata = {
+        **dataset.metadata,
+        "query_limit": query_limit,
+        "subset": f"first_{query_limit}_queries",
+        "source_dataset": DEFAULT_DATASET_PATH.name,
+    }
+    return PhoneticSearchDataset(
+        queries=dataset.queries[:query_limit],
+        words=dataset.words,
+        metadata=metadata,
+    )
+
+
+def load_default_dataset(query_limit: int | None = None) -> PhoneticSearchDataset:
     """デフォルトのデータセットを読み込む"""
-    return load_phonetic_search_dataset(str(DEFAULT_DATASET_PATH))
+    dataset = load_phonetic_search_dataset(str(DEFAULT_DATASET_PATH))
+    if query_limit is None:
+        return dataset
+    return _subset_dataset(dataset, query_limit=query_limit)
+
+
+def load_small_dataset() -> PhoneticSearchDataset:
+    """LLMの試行用に先頭10件へ絞った小データセットを読み込む"""
+    return load_default_dataset(query_limit=SMALL_DATASET_QUERY_COUNT)

--- a/src/soramimi_phonetic_search_dataset/evaluate.py
+++ b/src/soramimi_phonetic_search_dataset/evaluate.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 from soramimi_phonetic_search_dataset.dataset import load_default_dataset
 from soramimi_phonetic_search_dataset.schemas import (
+    PhoneticSearchDataset,
     PhoneticSearchMetrics,
     PhoneticSearchParameters,
     PhoneticSearchResult,
@@ -41,6 +42,7 @@ def calculate_recall(
 def evaluate_ranking_function_with_details(
     ranking_func: Callable[[list[str], list[str]], list[list[str]]],
     topn: int = 10,
+    dataset: PhoneticSearchDataset | None = None,
 ) -> PhoneticSearchResults:
     """
     ランキング関数の評価を行う
@@ -53,8 +55,8 @@ def evaluate_ranking_function_with_details(
     Returns:
         PhoneticSearchResults: 評価結果
     """
-    # デフォルトのデータセットを読み込む
-    dataset = load_default_dataset()
+    if dataset is None:
+        dataset = load_default_dataset()
 
     # クエリと正解を取得
     query_texts = [query.query for query in dataset.queries]
@@ -102,5 +104,8 @@ def evaluate_ranking_function_with_details(
 def evaluate_ranking_function(
     ranking_func: Callable[[list[str], list[str]], list[list[str]]],
     topn: int = 10,
+    dataset: PhoneticSearchDataset | None = None,
 ) -> float:
-    return evaluate_ranking_function_with_details(ranking_func, topn).metrics.recall
+    return evaluate_ranking_function_with_details(
+        ranking_func, topn, dataset=dataset
+    ).metrics.recall

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -6,7 +6,9 @@ from soramimi_phonetic_search_dataset import (
     PhoneticSearchDataset,
     PhoneticSearchQuery,
     evaluate_ranking_function,
+    load_default_dataset,
     load_phonetic_search_dataset,
+    load_small_dataset,
 )
 from soramimi_phonetic_search_dataset.evaluate import calculate_recall
 
@@ -51,6 +53,54 @@ def test_load_phonetic_search_dataset(sample_dataset, sample_dataset_file):
     ):
         assert loaded_query.query == original_query.query
         assert loaded_query.positive == original_query.positive
+
+
+def test_load_default_dataset_with_query_limit(monkeypatch, sample_dataset):
+    """クエリ数を絞ってデータセットを読み込める"""
+
+    def mock_load_dataset(path):
+        return sample_dataset
+
+    monkeypatch.setattr(
+        "soramimi_phonetic_search_dataset.dataset.load_phonetic_search_dataset",
+        mock_load_dataset,
+    )
+
+    limited_dataset = load_default_dataset(query_limit=1)
+    assert len(limited_dataset.queries) == 1
+    assert limited_dataset.words == sample_dataset.words
+    assert limited_dataset.metadata["query_limit"] == 1
+    assert limited_dataset.metadata["subset"] == "first_1_queries"
+
+
+def test_load_default_dataset_with_invalid_query_limit(monkeypatch, sample_dataset):
+    """query_limitは正の整数のみ受け付ける"""
+
+    def mock_load_dataset(path):
+        return sample_dataset
+
+    monkeypatch.setattr(
+        "soramimi_phonetic_search_dataset.dataset.load_phonetic_search_dataset",
+        mock_load_dataset,
+    )
+
+    with pytest.raises(ValueError, match="query_limit must be a positive integer"):
+        load_default_dataset(query_limit=0)
+
+
+def test_load_small_dataset(monkeypatch, sample_dataset):
+    """小データセットは十分小さい入力では元データをそのまま返す"""
+
+    def mock_load_dataset(path):
+        return sample_dataset
+
+    monkeypatch.setattr(
+        "soramimi_phonetic_search_dataset.dataset.load_phonetic_search_dataset",
+        mock_load_dataset,
+    )
+
+    loaded_dataset = load_small_dataset()
+    assert loaded_dataset is sample_dataset
 
 
 def test_calculate_recall():
@@ -99,3 +149,22 @@ def test_evaluate_ranking_function(monkeypatch, sample_dataset):
 
     recall = evaluate_ranking_function(ranking_func=perfect_ranking, topn=2)
     assert recall == 1.0  # 全てのクエリで正解を含む
+
+
+def test_evaluate_ranking_function_with_explicit_dataset(sample_dataset):
+    """明示的に渡したデータセットで評価できる"""
+
+    def perfect_ranking(query_texts, wordlist_texts):
+        assert query_texts == ["タロウ", "ハナコ"]
+        assert wordlist_texts == sample_dataset.words
+        return [
+            ["タロー", "タロ", "タロウ", "ハナコ", "ハナ", "ハナゴ"],
+            ["ハナ", "ハナゴ", "ハナコ", "タロウ", "タロー", "タロ"],
+        ]
+
+    recall = evaluate_ranking_function(
+        ranking_func=perfect_ranking,
+        topn=2,
+        dataset=sample_dataset,
+    )
+    assert recall == 1.0


### PR DESCRIPTION
## 概要
- load_small_dataset() を追加
- evaluate_ranking_function 系で明示的なデータセット指定をサポート
- サンプル/再現スクリプトに --dataset_size small を追加
- README に小データセットの使い方を追記

## 変更点
- 小データセットは既存の単語リストをそのまま使い、クエリ数だけ10件に絞ります
- 既存のデフォルト挙動は維持します
