### PR TITLE
refactor: simplify ranking evaluation API

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -27,8 +27,8 @@ def my_ranking_function(query_texts: list[str], wordlist_texts: list[str]) -> li
     return ranked_wordlists
 
 # Evaluate your function
-recall = evaluate_ranking_function(ranking_func=my_ranking_function, topn=10)
-print(f"Recall@10: {recall}")
+results = evaluate_ranking_function(ranking_func=my_ranking_function, topn=10)
+print(f"Recall@10: {results.metrics.recall}")
 ```
 
 If you want a cheaper LLM smoke test, you can use the bundled small dataset, which keeps the original word list and limits evaluation to the first 10 queries.
@@ -40,12 +40,12 @@ from soramimi_phonetic_search_dataset import (
 )
 
 small_dataset = load_small_dataset()
-recall = evaluate_ranking_function(
+results = evaluate_ranking_function(
     ranking_func=my_ranking_function,
     topn=10,
     dataset=small_dataset,
 )
-print(f"Recall@10 on small dataset: {recall}")
+print(f"Recall@10 on small dataset: {results.metrics.recall}")
 ```
 
 The sample script in this repository also supports `--dataset_size small`.
@@ -62,7 +62,8 @@ The following ranking functions are provided:
 ```python
 from soramimi_phonetic_search_dataset import rank_by_mora_editdistance
 
-recall = evaluate_ranking_function(ranking_func=rank_by_mora_editdistance, topn=10)
+results = evaluate_ranking_function(ranking_func=rank_by_mora_editdistance, topn=10)
+print(results.metrics.recall)
 ```
 
 ## Dataset Usage Notes

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ def my_ranking_function(query_texts: list[str], wordlist_texts: list[str]) -> li
     return ranked_wordlists
 
 # 評価の実行
-recall = evaluate_ranking_function(ranking_func=my_ranking_function, topn=10)
-print(f"Recall@10: {recall}")
+results = evaluate_ranking_function(ranking_func=my_ranking_function, topn=10)
+print(f"Recall@10: {results.metrics.recall}")
 ```
 
 LLMでの試行回数を減らしたい場合は、先頭10件のクエリだけを使う小データセットも利用できます。
@@ -42,12 +42,12 @@ from soramimi_phonetic_search_dataset import (
 )
 
 small_dataset = load_small_dataset()
-recall = evaluate_ranking_function(
+results = evaluate_ranking_function(
     ranking_func=my_ranking_function,
     topn=10,
     dataset=small_dataset,
 )
-print(f"Recall@10 on small dataset: {recall}")
+print(f"Recall@10 on small dataset: {results.metrics.recall}")
 ```
 
 リポジトリ内のサンプルスクリプトでも `--dataset_size small` を指定すると、同じ10件版で評価できます。
@@ -64,7 +64,8 @@ print(f"Recall@10 on small dataset: {recall}")
 ```python
 from soramimi_phonetic_search_dataset import rank_by_mora_editdistance
 
-recall = evaluate_ranking_function(ranking_func=rank_by_mora_editdistance, topn=10)
+results = evaluate_ranking_function(ranking_func=rank_by_mora_editdistance, topn=10)
+print(results.metrics.recall)
 ```
 
 ## ライセンス

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from reproduce_leaderboard.methods.common.reranker import rerank_by_llm
 from soramimi_phonetic_search_dataset import (
-    evaluate_ranking_function_with_details,
+    evaluate_ranking_function,
     load_default_dataset,
     load_small_dataset,
     rank_by_kanasim,
@@ -211,7 +211,7 @@ def main():
     )
 
     # 評価を実行
-    results = evaluate_ranking_function_with_details(
+    results = evaluate_ranking_function(
         ranking_func=rank_func,
         topn=args.topn,
         dataset=dataset,

--- a/reproduce_leaderboard/methods/common/evaluate_ranking.py
+++ b/reproduce_leaderboard/methods/common/evaluate_ranking.py
@@ -16,7 +16,7 @@ from reranker import (
     rerank_by_llm,
 )
 from soramimi_phonetic_search_dataset import (
-    evaluate_ranking_function_with_details,
+    evaluate_ranking_function,
     load_default_dataset,
     load_small_dataset,
     rank_by_kanasim,
@@ -417,7 +417,7 @@ def main():
             return base_rank_func(q, w, **rank_kwargs)
 
     # 評価を実行
-    results = evaluate_ranking_function_with_details(
+    results = evaluate_ranking_function(
         ranking_func=rank_func,
         topn=args.topn,
         dataset=dataset,

--- a/src/soramimi_phonetic_search_dataset/__init__.py
+++ b/src/soramimi_phonetic_search_dataset/__init__.py
@@ -9,7 +9,7 @@ from .dataset import (
     load_phonetic_search_dataset,
     load_small_dataset,
 )
-from .evaluate import evaluate_ranking_function, evaluate_ranking_function_with_details
+from .evaluate import evaluate_ranking_function
 from .ranking import (
     rank_by_kanasim,
     rank_by_mora_editdistance,
@@ -20,7 +20,6 @@ from .schemas import PhoneticSearchDataset, PhoneticSearchQuery
 
 __all__ = [
     "evaluate_ranking_function",
-    "evaluate_ranking_function_with_details",
     "rank_by_mora_editdistance",
     "rank_by_vowel_consonant_editdistance",
     "rank_by_phoneme_editdistance",

--- a/src/soramimi_phonetic_search_dataset/evaluate.py
+++ b/src/soramimi_phonetic_search_dataset/evaluate.py
@@ -1,6 +1,6 @@
 import time
 from datetime import datetime
-from typing import Callable
+from typing import Any, Callable, TypeAlias
 
 from soramimi_phonetic_search_dataset.dataset import load_default_dataset
 from soramimi_phonetic_search_dataset.schemas import (
@@ -10,6 +10,28 @@ from soramimi_phonetic_search_dataset.schemas import (
     PhoneticSearchResult,
     PhoneticSearchResults,
 )
+
+
+RankingFunc: TypeAlias = Callable[
+    [list[str], list[str]],
+    list[list[str]] | tuple[list[list[str]], list[dict[str, Any]]],
+]
+"""\
+評価対象のランキング関数のシグネチャ。
+
+入力として query_texts と wordlist_texts を受け取り、各クエリに対する ranked_words の
+リストを返す。必要に応じて、各クエリに対応する metadata のリストを組にして返してもよい。
+"""
+
+
+def _normalize_ranking_output(
+    ranking_output: list[list[str]] | tuple[list[list[str]], list[dict[str, Any]]],
+) -> tuple[list[list[str]], list[dict[str, Any]] | None]:
+    if isinstance(ranking_output, tuple):
+        ranked_wordlists, metadatas = ranking_output
+        return ranked_wordlists, metadatas
+
+    return ranking_output, None
 
 
 def calculate_recall(
@@ -39,8 +61,8 @@ def calculate_recall(
     return sum(recalls) / len(recalls) if recalls else 0.0
 
 
-def evaluate_ranking_function_with_details(
-    ranking_func: Callable[[list[str], list[str]], list[list[str]]],
+def evaluate_ranking_function(
+    ranking_func: RankingFunc,
     topn: int = 10,
     dataset: PhoneticSearchDataset | None = None,
 ) -> PhoneticSearchResults:
@@ -49,7 +71,7 @@ def evaluate_ranking_function_with_details(
 
     Args:
         ranking_func: ランキング関数。query_textsとwordlist_textsを受け取り、
-                     各クエリに対する単語リストのランキングを返す
+                 各クエリに対する単語リストのランキング、またはランキングとmetadataを返す
         topn: 評価に使用する上位n件
 
     Returns:
@@ -64,8 +86,9 @@ def evaluate_ranking_function_with_details(
 
     # ランキングを実行（実行時間を計測）
     start_time = time.time()
-    ranked_wordlists = ranking_func(query_texts, dataset.words)
+    ranking_output = ranking_func(query_texts, dataset.words)
     execution_time = time.time() - start_time
+    ranked_wordlists, metadatas = _normalize_ranking_output(ranking_output)
 
     # Recallを計算
     recall = calculate_recall(ranked_wordlists, positive_texts, topn=topn)
@@ -76,9 +99,10 @@ def evaluate_ranking_function_with_details(
             query=query.query,
             ranked_words=wordlist[:topn],
             positive_words=positive_text,
+            metadata=metadatas[index] if metadatas is not None else None,
         )
-        for query, wordlist, positive_text in zip(
-            dataset.queries, ranked_wordlists, positive_texts
+        for index, (query, wordlist, positive_text) in enumerate(
+            zip(dataset.queries, ranked_wordlists, positive_texts)
         )
     ]
 
@@ -99,13 +123,3 @@ def evaluate_ranking_function_with_details(
         metrics=metrics,
         results=results,
     )
-
-
-def evaluate_ranking_function(
-    ranking_func: Callable[[list[str], list[str]], list[list[str]]],
-    topn: int = 10,
-    dataset: PhoneticSearchDataset | None = None,
-) -> float:
-    return evaluate_ranking_function_with_details(
-        ranking_func, topn, dataset=dataset
-    ).metrics.recall

--- a/src/soramimi_phonetic_search_dataset/schemas.py
+++ b/src/soramimi_phonetic_search_dataset/schemas.py
@@ -27,6 +27,7 @@ class PhoneticSearchResult:
     query: str
     ranked_words: list[str]
     positive_words: list[str]
+    metadata: dict[str, Any] | None = None
     thoughts: list[str] | None = None
 
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -182,8 +182,8 @@ def test_evaluate_ranking_function(monkeypatch, sample_dataset):
                 results.append(["ハナ", "ハナゴ", "ハナコ", "タロウ", "タロー", "タロ"])
         return results
 
-    recall = evaluate_ranking_function(ranking_func=perfect_ranking, topn=2)
-    assert recall == 1.0  # 全てのクエリで正解を含む
+    results = evaluate_ranking_function(ranking_func=perfect_ranking, topn=2)
+    assert results.metrics.recall == 1.0  # 全てのクエリで正解を含む
 
 
 def test_evaluate_ranking_function_with_explicit_dataset(sample_dataset):
@@ -197,9 +197,34 @@ def test_evaluate_ranking_function_with_explicit_dataset(sample_dataset):
             ["ハナ", "ハナゴ", "ハナコ", "タロウ", "タロー", "タロ"],
         ]
 
-    recall = evaluate_ranking_function(
+    results = evaluate_ranking_function(
         ranking_func=perfect_ranking,
         topn=2,
         dataset=sample_dataset,
     )
-    assert recall == 1.0
+    assert results.metrics.recall == 1.0
+
+
+def test_evaluate_ranking_function_with_metadata(sample_dataset):
+    """ランキング関数がmetadataを返しても評価できる"""
+
+    def ranking_with_metadata(query_texts, wordlist_texts):
+        assert query_texts == ["タロウ", "ハナコ"]
+        assert wordlist_texts == sample_dataset.words
+        return [
+            ["タロー", "タロ", "タロウ", "ハナコ", "ハナ", "ハナゴ"],
+            ["ハナ", "ハナゴ", "ハナコ", "タロウ", "タロー", "タロ"],
+        ], [
+            {"source": "exact", "score": 1.0},
+            {"source": "fuzzy", "score": 0.8},
+        ]
+
+    results = evaluate_ranking_function(
+        ranking_func=ranking_with_metadata,
+        topn=2,
+        dataset=sample_dataset,
+    )
+
+    assert results.metrics.recall == 1.0
+    assert results.results[0].metadata == {"source": "exact", "score": 1.0}
+    assert results.results[1].metadata == {"source": "fuzzy", "score": 0.8}

--- a/tests/test_reproduce_evaluate_ranking.py
+++ b/tests/test_reproduce_evaluate_ranking.py
@@ -87,7 +87,7 @@ def test_正常系_query_limit指定でdefault_datasetを絞って評価でき�
     )
     monkeypatch.setattr(
         evaluate_ranking,
-        "evaluate_ranking_function_with_details",
+        "evaluate_ranking_function",
         lambda ranking_func, topn, dataset: sample_results,
     )
     monkeypatch.setattr(
@@ -120,7 +120,7 @@ def test_正常系_query_offset指定でdefault_datasetをずらして評価で�
     )
     monkeypatch.setattr(
         evaluate_ranking,
-        "evaluate_ranking_function_with_details",
+        "evaluate_ranking_function",
         lambda ranking_func, topn, dataset: sample_results,
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- rename the detailed evaluation entrypoint to evaluate_ranking_function
- remove the old float-returning evaluate_ranking_function API
- update callers, tests, and README examples to use results.metrics.recall

## Testing
- uv run pytest tests/test_evaluate.py tests/test_reproduce_evaluate_ranking.py