### PR TITLE
Refactor evaluation metadata schema

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -219,18 +219,20 @@ def main():
 
     # パラメータを設定
     results.parameters.rank_func = args.rank_func
-    results.parameters.vowel_ratio = (
-        args.vowel_ratio if args.rank_func in ["kanasim", "vowel_consonant"] else None
-    )
-    results.parameters.rerank = args.rerank
-    results.parameters.rerank_model_name = (
-        args.rerank_model_name if args.rerank else None
-    )
-    results.parameters.rerank_reasoning_effort = (
-        args.rerank_reasoning_effort if args.rerank else None
-    )
-    results.parameters.rerank_input_size = (
-        args.rerank_input_size if args.rerank else None
+    results.parameters.metadata.update(
+        {
+            "vowel_ratio": (
+                args.vowel_ratio
+                if args.rank_func in ["kanasim", "vowel_consonant"]
+                else None
+            ),
+            "rerank": args.rerank,
+            "rerank_model_name": args.rerank_model_name if args.rerank else None,
+            "rerank_reasoning_effort": (
+                args.rerank_reasoning_effort if args.rerank else None
+            ),
+            "rerank_input_size": args.rerank_input_size if args.rerank else None,
+        }
     )
 
     print("Recall: ", results.metrics.recall)

--- a/reproduce_leaderboard/methods/common/batch_reranker.py
+++ b/reproduce_leaderboard/methods/common/batch_reranker.py
@@ -21,6 +21,33 @@ from soramimi_phonetic_search_dataset.schemas import (
 )
 
 
+def _build_rerank_metrics_metadata(
+    *,
+    model_name: str,
+    token_usage: Any,
+    token_cost: Any,
+    discount_factor: float | None = None,
+) -> dict[str, Any]:
+    metadata = {
+        "model_name": model_name,
+        "token_usage": {
+            "input_tokens": token_usage.input_tokens,
+            "output_tokens": token_usage.output_tokens,
+            "reasoning_tokens": token_usage.reasoning_tokens,
+            "total_tokens": token_usage.total_tokens,
+        },
+        "cost": {
+            "input_cost": token_cost.input_cost,
+            "output_cost": token_cost.output_cost,
+            "reasoning_cost": token_cost.reasoning_cost,
+            "total_cost": token_cost.total_cost,
+        },
+    }
+    if discount_factor is not None:
+        metadata["discount_factor"] = discount_factor
+    return metadata
+
+
 def prepare_rerank_candidates(
     base_ranked_wordlists: list[list[str]],
     positive_texts: list[list[str]],
@@ -63,7 +90,7 @@ def _build_results_from_ranked_wordlists(
             query=query,
             ranked_words=wordlist[:topn],
             positive_words=positive_text,
-            thoughts=structured_output.get("thoughts"),
+            metadata=structured_output,
         )
         for query, wordlist, positive_text, structured_output in zip(
             query_texts,
@@ -161,18 +188,22 @@ def retrieve_openai_batch_evaluation_results(
         execution_time=retrieved.execution_time,
     )
     results.parameters.rank_func = rank_func
-    results.parameters.vowel_ratio = (
-        vowel_ratio if rank_func in ["kanasim", "vowel_consonant"] else None
+    results.parameters.metadata.update(
+        {
+            "vowel_ratio": (
+                vowel_ratio if rank_func in ["kanasim", "vowel_consonant"] else None
+            ),
+            "rerank": True,
+            "rerank_model_name": model_name,
+            "rerank_reasoning_effort": reasoning_effort,
+            "rerank_prompt_template": prompt_template,
+            "rerank_include_thoughts": rerank_include_thoughts,
+            "rerank_input_transform": input_transform,
+            "rerank_input_size": rerank_input_size,
+            "rerank_backend": backend,
+            "rerank_batch_id": batch_state["batch_id"],
+        }
     )
-    results.parameters.rerank = True
-    results.parameters.rerank_model_name = model_name
-    results.parameters.rerank_reasoning_effort = reasoning_effort
-    results.parameters.rerank_prompt_template = prompt_template
-    results.parameters.rerank_include_thoughts = rerank_include_thoughts
-    results.parameters.rerank_input_transform = input_transform
-    results.parameters.rerank_input_size = rerank_input_size
-    results.parameters.rerank_backend = backend
-    results.parameters.rerank_batch_id = batch_state["batch_id"]
 
     token_usage = get_last_token_usage()
     token_cost = calculate_token_cost(
@@ -180,12 +211,10 @@ def retrieve_openai_batch_evaluation_results(
         token_usage,
         discount_factor=OPENAI_BATCH_DISCOUNT_FACTOR,
     )
-    results.metrics.rerank_input_tokens = token_usage.input_tokens
-    results.metrics.rerank_output_tokens = token_usage.output_tokens
-    results.metrics.rerank_reasoning_tokens = token_usage.reasoning_tokens
-    results.metrics.rerank_total_tokens = token_usage.total_tokens
-    results.metrics.rerank_input_cost = token_cost.input_cost
-    results.metrics.rerank_output_cost = token_cost.output_cost
-    results.metrics.rerank_reasoning_cost = token_cost.reasoning_cost
-    results.metrics.rerank_total_cost = token_cost.total_cost
+    results.metrics.metadata = _build_rerank_metrics_metadata(
+        model_name=model_name,
+        token_usage=token_usage,
+        token_cost=token_cost,
+        discount_factor=OPENAI_BATCH_DISCOUNT_FACTOR,
+    )
     return results

--- a/reproduce_leaderboard/methods/common/evaluate_ranking.py
+++ b/reproduce_leaderboard/methods/common/evaluate_ranking.py
@@ -10,9 +10,9 @@ from batch_reranker import (
 )
 from reranker import (
     calculate_token_cost,
-    get_last_token_usage,
     get_rerank_response_format,
     get_last_structured_outputs,
+    get_last_token_usage,
     rerank_by_llm,
 )
 from soramimi_phonetic_search_dataset import (
@@ -24,6 +24,29 @@ from soramimi_phonetic_search_dataset import (
     rank_by_phoneme_editdistance,
     rank_by_vowel_consonant_editdistance,
 )
+from soramimi_phonetic_search_dataset.evaluate import RankingFunctionOutput
+
+
+def build_rerank_metrics_metadata(
+    model_name: str,
+    token_usage,
+    token_cost,
+) -> dict[str, object]:
+    return {
+        "model_name": model_name,
+        "token_usage": {
+            "input_tokens": token_usage.input_tokens,
+            "output_tokens": token_usage.output_tokens,
+            "reasoning_tokens": token_usage.reasoning_tokens,
+            "total_tokens": token_usage.total_tokens,
+        },
+        "cost": {
+            "input_cost": token_cost.input_cost,
+            "output_cost": token_cost.output_cost,
+            "reasoning_cost": token_cost.reasoning_cost,
+            "total_cost": token_cost.total_cost,
+        },
+    }
 
 
 def create_reranking_function(
@@ -60,9 +83,7 @@ def create_reranking_function(
         組み合わせたランキング関数
     """
 
-    def combined_rank_func(
-        query_texts: list[str], wordlist_texts: list[str]
-    ) -> list[list[str]]:
+    def combined_rank_func(query_texts: list[str], wordlist_texts: list[str]):
         # ベースのランキングを実行
         base_ranked_wordlists = base_rank_func(
             query_texts, wordlist_texts, **base_rank_kwargs
@@ -87,7 +108,21 @@ def create_reranking_function(
             batch_size=rerank_batch_size,
             rerank_interval=rerank_interval,
         )
-        return reranked_wordlists
+        token_usage = get_last_token_usage()
+        token_cost = calculate_token_cost(rerank_model_name, token_usage)
+        result_metadata = (
+            get_last_structured_outputs() if rerank_include_thoughts else None
+        )
+        metrics_metadata = build_rerank_metrics_metadata(
+            rerank_model_name,
+            token_usage,
+            token_cost,
+        )
+        return RankingFunctionOutput(
+            ranked_wordlists=reranked_wordlists,
+            result_metadata=result_metadata,
+            metrics_metadata=metrics_metadata,
+        )
 
     return combined_rank_func
 
@@ -374,8 +409,12 @@ def main():
             input_transform=args.rerank_input_transform,
             backend=args.rerank_backend,
         )
-        results.parameters.query_limit = effective_query_limit
-        results.parameters.query_offset = effective_query_offset
+        results.parameters.metadata.update(
+            {
+                "query_limit": effective_query_limit,
+                "query_offset": effective_query_offset,
+            }
+        )
 
         print("Recall: ", results.metrics.recall)
         print("Execution time: ", results.metrics.execution_time)
@@ -425,47 +464,38 @@ def main():
 
     # パラメータを設定
     results.parameters.rank_func = args.rank_func
-    results.parameters.query_limit = effective_query_limit
-    results.parameters.query_offset = effective_query_offset
-    results.parameters.vowel_ratio = (
-        args.vowel_ratio if args.rank_func in ["kanasim", "vowel_consonant"] else None
+    results.parameters.metadata.update(
+        {
+            "query_limit": effective_query_limit,
+            "query_offset": effective_query_offset,
+            "vowel_ratio": (
+                args.vowel_ratio
+                if args.rank_func in ["kanasim", "vowel_consonant"]
+                else None
+            ),
+            "rerank": args.rerank,
+            "rerank_model_name": args.rerank_model_name if args.rerank else None,
+            "rerank_reasoning_effort": (
+                args.rerank_reasoning_effort if args.rerank else None
+            ),
+            "rerank_prompt_template": (
+                args.rerank_prompt_template if args.rerank else None
+            ),
+            "rerank_include_thoughts": (
+                args.rerank_include_thoughts if args.rerank else None
+            ),
+            "rerank_input_transform": (
+                args.rerank_input_transform if args.rerank else None
+            ),
+            "rerank_input_size": args.rerank_input_size if args.rerank else None,
+            "rerank_backend": args.rerank_backend if args.rerank else None,
+            "rerank_batch_id": None,
+        }
     )
-    results.parameters.rerank = args.rerank
-    results.parameters.rerank_model_name = (
-        args.rerank_model_name if args.rerank else None
-    )
-    results.parameters.rerank_reasoning_effort = (
-        args.rerank_reasoning_effort if args.rerank else None
-    )
-    results.parameters.rerank_prompt_template = (
-        args.rerank_prompt_template if args.rerank else None
-    )
-    results.parameters.rerank_include_thoughts = (
-        args.rerank_include_thoughts if args.rerank else None
-    )
-    results.parameters.rerank_input_transform = (
-        args.rerank_input_transform if args.rerank else None
-    )
-    results.parameters.rerank_input_size = (
-        args.rerank_input_size if args.rerank else None
-    )
-    results.parameters.rerank_backend = args.rerank_backend if args.rerank else None
-    results.parameters.rerank_batch_id = None
     if args.rerank and args.rerank_include_thoughts:
         structured_outputs = get_last_structured_outputs()
         for result, structured_output in zip(results.results, structured_outputs):
-            result.thoughts = structured_output.get("thoughts")
-    if args.rerank:
-        token_usage = get_last_token_usage()
-        token_cost = calculate_token_cost(args.rerank_model_name, token_usage)
-        results.metrics.rerank_input_tokens = token_usage.input_tokens
-        results.metrics.rerank_output_tokens = token_usage.output_tokens
-        results.metrics.rerank_reasoning_tokens = token_usage.reasoning_tokens
-        results.metrics.rerank_total_tokens = token_usage.total_tokens
-        results.metrics.rerank_input_cost = token_cost.input_cost
-        results.metrics.rerank_output_cost = token_cost.output_cost
-        results.metrics.rerank_reasoning_cost = token_cost.reasoning_cost
-        results.metrics.rerank_total_cost = token_cost.total_cost
+            result.metadata = structured_output
 
     print("Recall: ", results.metrics.recall)
     print("Execution time: ", results.metrics.execution_time)

--- a/src/soramimi_phonetic_search_dataset/__init__.py
+++ b/src/soramimi_phonetic_search_dataset/__init__.py
@@ -9,7 +9,7 @@ from .dataset import (
     load_phonetic_search_dataset,
     load_small_dataset,
 )
-from .evaluate import evaluate_ranking_function
+from .evaluate import RankingFunctionOutput, evaluate_ranking_function
 from .ranking import (
     rank_by_kanasim,
     rank_by_mora_editdistance,
@@ -20,6 +20,7 @@ from .schemas import PhoneticSearchDataset, PhoneticSearchQuery
 
 __all__ = [
     "evaluate_ranking_function",
+    "RankingFunctionOutput",
     "rank_by_mora_editdistance",
     "rank_by_vowel_consonant_editdistance",
     "rank_by_phoneme_editdistance",

--- a/src/soramimi_phonetic_search_dataset/evaluate.py
+++ b/src/soramimi_phonetic_search_dataset/evaluate.py
@@ -1,4 +1,5 @@
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, TypeAlias
 
@@ -12,26 +13,37 @@ from soramimi_phonetic_search_dataset.schemas import (
 )
 
 
+@dataclass
+class RankingFunctionOutput:
+    ranked_wordlists: list[list[str]]
+    result_metadata: list[dict[str, Any]] | None = None
+    metrics_metadata: dict[str, Any] | None = None
+
+
 RankingFunc: TypeAlias = Callable[
     [list[str], list[str]],
-    list[list[str]] | tuple[list[list[str]], list[dict[str, Any]]],
+    list[list[str]] | RankingFunctionOutput,
 ]
 """\
 評価対象のランキング関数のシグネチャ。
 
 入力として query_texts と wordlist_texts を受け取り、各クエリに対する ranked_words の
-リストを返す。必要に応じて、各クエリに対応する metadata のリストを組にして返してもよい。
+リストを返す。必要に応じて RankingFunctionOutput を返し、各クエリに対応する
+metadata のリストや、評価全体に紐づく metrics metadata を渡してもよい。
 """
 
 
 def _normalize_ranking_output(
-    ranking_output: list[list[str]] | tuple[list[list[str]], list[dict[str, Any]]],
-) -> tuple[list[list[str]], list[dict[str, Any]] | None]:
-    if isinstance(ranking_output, tuple):
-        ranked_wordlists, metadatas = ranking_output
-        return ranked_wordlists, metadatas
+    ranking_output: list[list[str]] | RankingFunctionOutput,
+) -> tuple[list[list[str]], list[dict[str, Any]] | None, dict[str, Any] | None]:
+    if isinstance(ranking_output, list):
+        return ranking_output, None, None
 
-    return ranking_output, None
+    return (
+        ranking_output.ranked_wordlists,
+        ranking_output.result_metadata,
+        ranking_output.metrics_metadata,
+    )
 
 
 def calculate_recall(
@@ -88,7 +100,9 @@ def evaluate_ranking_function(
     start_time = time.time()
     ranking_output = ranking_func(query_texts, dataset.words)
     execution_time = time.time() - start_time
-    ranked_wordlists, metadatas = _normalize_ranking_output(ranking_output)
+    ranked_wordlists, metadatas, metrics_metadata = _normalize_ranking_output(
+        ranking_output
+    )
 
     # Recallを計算
     recall = calculate_recall(ranked_wordlists, positive_texts, topn=topn)
@@ -116,6 +130,7 @@ def evaluate_ranking_function(
     metrics = PhoneticSearchMetrics(
         recall=recall,
         execution_time=execution_time,  # 実行時間を追加
+        metadata=metrics_metadata or {},
     )
 
     return PhoneticSearchResults(

--- a/src/soramimi_phonetic_search_dataset/schemas.py
+++ b/src/soramimi_phonetic_search_dataset/schemas.py
@@ -28,40 +28,50 @@ class PhoneticSearchResult:
     ranked_words: list[str]
     positive_words: list[str]
     metadata: dict[str, Any] | None = None
-    thoughts: list[str] | None = None
 
 
 @dataclass
 class PhoneticSearchMetrics:
     recall: float
     execution_time: float
-    rerank_input_tokens: int | None = None
-    rerank_output_tokens: int | None = None
-    rerank_reasoning_tokens: int | None = None
-    rerank_total_tokens: int | None = None
-    rerank_input_cost: float | None = None
-    rerank_output_cost: float | None = None
-    rerank_reasoning_cost: float | None = None
-    rerank_total_cost: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PhoneticSearchMetrics":
+        metadata = data.get("metadata", {})
+        extra_metadata = {
+            key: value
+            for key, value in data.items()
+            if key not in {"recall", "execution_time", "metadata"}
+        }
+        return cls(
+            recall=data["recall"],
+            execution_time=data["execution_time"],
+            metadata={**extra_metadata, **metadata},
+        )
 
 
 @dataclass
 class PhoneticSearchParameters:
     topn: int
     rank_func: str
-    query_limit: int | None = None
-    query_offset: int | None = None
-    vowel_ratio: float | None = None
-    rerank: bool = False
-    rerank_backend: str | None = None
-    rerank_model_name: str | None = None
-    rerank_batch_id: str | None = None
-    rerank_reasoning_effort: str | None = None
-    rerank_prompt_template: str | None = None
-    rerank_include_thoughts: bool | None = None
-    rerank_input_transform: str | None = None
-    rerank_input_size: int | None = None
     execution_timestamp: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PhoneticSearchParameters":
+        metadata = data.get("metadata", {})
+        extra_metadata = {
+            key: value
+            for key, value in data.items()
+            if key not in {"topn", "rank_func", "execution_timestamp", "metadata"}
+        }
+        return cls(
+            topn=data["topn"],
+            rank_func=data["rank_func"],
+            execution_timestamp=data.get("execution_timestamp"),
+            metadata={**extra_metadata, **metadata},
+        )
 
 
 @dataclass
@@ -74,7 +84,7 @@ class PhoneticSearchResults:
     def from_dict(cls, data: dict[str, Any]) -> "PhoneticSearchResults":
         results = [PhoneticSearchResult(**result) for result in data["results"]]
         return cls(
-            parameters=PhoneticSearchParameters(**data["parameters"]),
-            metrics=PhoneticSearchMetrics(**data["metrics"]),
+            parameters=PhoneticSearchParameters.from_dict(data["parameters"]),
+            metrics=PhoneticSearchMetrics.from_dict(data["metrics"]),
             results=results,
         )

--- a/tests/test_batch_reranker.py
+++ b/tests/test_batch_reranker.py
@@ -104,9 +104,27 @@ def test_retrieve_openai_batch_evaluation_results_sets_metadata(tmp_path, monkey
     )
 
     assert results.parameters.rank_func == "vowel_consonant"
-    assert results.parameters.rerank_batch_id == "batch-123"
-    assert results.parameters.rerank_backend == "openai_batch"
+    assert results.parameters.metadata["rerank_batch_id"] == "batch-123"
+    assert results.parameters.metadata["rerank_backend"] == "openai_batch"
+    assert results.parameters.metadata["vowel_ratio"] == 0.5
     assert results.metrics.execution_time == 12.5
-    assert results.metrics.rerank_total_tokens == 33
-    assert results.metrics.rerank_total_cost == 0.15
-    assert results.results[0].thoughts == ["母音列が一致"]
+    assert results.metrics.metadata == {
+        "model_name": "gpt-5.4",
+        "token_usage": {
+            "input_tokens": 11,
+            "output_tokens": 13,
+            "reasoning_tokens": 9,
+            "total_tokens": 33,
+        },
+        "cost": {
+            "input_cost": 0.05,
+            "output_cost": 0.1,
+            "reasoning_cost": 0.025,
+            "total_cost": 0.15,
+        },
+        "discount_factor": 0.5,
+    }
+    assert results.results[0].metadata == {
+        "thoughts": ["母音列が一致"],
+        "reranked": [0, 1],
+    }

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -10,7 +10,10 @@ from soramimi_phonetic_search_dataset import (
     load_phonetic_search_dataset,
     load_small_dataset,
 )
-from soramimi_phonetic_search_dataset.evaluate import calculate_recall
+from soramimi_phonetic_search_dataset.evaluate import (
+    RankingFunctionOutput,
+    calculate_recall,
+)
 
 
 @pytest.fixture
@@ -211,13 +214,16 @@ def test_evaluate_ranking_function_with_metadata(sample_dataset):
     def ranking_with_metadata(query_texts, wordlist_texts):
         assert query_texts == ["タロウ", "ハナコ"]
         assert wordlist_texts == sample_dataset.words
-        return [
-            ["タロー", "タロ", "タロウ", "ハナコ", "ハナ", "ハナゴ"],
-            ["ハナ", "ハナゴ", "ハナコ", "タロウ", "タロー", "タロ"],
-        ], [
-            {"source": "exact", "score": 1.0},
-            {"source": "fuzzy", "score": 0.8},
-        ]
+        return RankingFunctionOutput(
+            ranked_wordlists=[
+                ["タロー", "タロ", "タロウ", "ハナコ", "ハナ", "ハナゴ"],
+                ["ハナ", "ハナゴ", "ハナコ", "タロウ", "タロー", "タロ"],
+            ],
+            result_metadata=[
+                {"source": "exact", "score": 1.0, "thoughts": ["母音列が近い"]},
+                {"source": "fuzzy", "score": 0.8, "thoughts": ["子音差を確認"]},
+            ],
+        )
 
     results = evaluate_ranking_function(
         ranking_func=ranking_with_metadata,
@@ -226,5 +232,45 @@ def test_evaluate_ranking_function_with_metadata(sample_dataset):
     )
 
     assert results.metrics.recall == 1.0
-    assert results.results[0].metadata == {"source": "exact", "score": 1.0}
-    assert results.results[1].metadata == {"source": "fuzzy", "score": 0.8}
+    assert results.results[0].metadata == {
+        "source": "exact",
+        "score": 1.0,
+        "thoughts": ["母音列が近い"],
+    }
+    assert results.results[1].metadata == {
+        "source": "fuzzy",
+        "score": 0.8,
+        "thoughts": ["子音差を確認"],
+    }
+
+
+def test_evaluate_ranking_function_with_metrics_metadata(sample_dataset):
+    """ランキング関数が全体メトリクスmetadataを返しても評価できる"""
+
+    def ranking_with_metrics_metadata(query_texts, wordlist_texts):
+        assert query_texts == ["タロウ", "ハナコ"]
+        assert wordlist_texts == sample_dataset.words
+        return RankingFunctionOutput(
+            ranked_wordlists=[
+                ["タロー", "タロ", "タロウ", "ハナコ", "ハナ", "ハナゴ"],
+                ["ハナ", "ハナゴ", "ハナコ", "タロウ", "タロー", "タロ"],
+            ],
+            metrics_metadata={
+                "model_name": "gpt-5.4",
+                "token_usage": {"total_tokens": 123},
+                "cost": {"total_cost": 0.42},
+            },
+        )
+
+    results = evaluate_ranking_function(
+        ranking_func=ranking_with_metrics_metadata,
+        topn=2,
+        dataset=sample_dataset,
+    )
+
+    assert results.metrics.recall == 1.0
+    assert results.metrics.metadata == {
+        "model_name": "gpt-5.4",
+        "token_usage": {"total_tokens": 123},
+        "cost": {"total_cost": 0.42},
+    }

--- a/tests/test_reproduce_evaluate_ranking.py
+++ b/tests/test_reproduce_evaluate_ranking.py
@@ -100,8 +100,8 @@ def test_正常系_query_limit指定でdefault_datasetを絞って評価でき�
 
     assert captured["query_limit"] == 100
     assert captured["query_offset"] == 0
-    assert sample_results.parameters.query_limit == 100
-    assert sample_results.parameters.query_offset == 0
+    assert sample_results.parameters.metadata["query_limit"] == 100
+    assert sample_results.parameters.metadata["query_offset"] == 0
 
 
 def test_正常系_query_offset指定でdefault_datasetをずらして評価できる(
@@ -140,8 +140,8 @@ def test_正常系_query_offset指定でdefault_datasetをずらして評価で�
 
     assert captured["query_limit"] == 50
     assert captured["query_offset"] == 100
-    assert sample_results.parameters.query_limit == 50
-    assert sample_results.parameters.query_offset == 100
+    assert sample_results.parameters.metadata["query_limit"] == 50
+    assert sample_results.parameters.metadata["query_offset"] == 100
 
 
 def test_異常系_small_datasetとquery_limitの併用はエラーになる(


### PR DESCRIPTION
## Summary
- move thoughts and rerank-specific per-query data into result metadata
- replace fixed rerank metric and parameter fields with metadata-centric structures
- introduce RankingFunctionOutput as the public ranking function return type and keep old saved JSON readable via from_dict

## Testing
- uv run pytest tests/test_reproduce_evaluate_ranking.py tests/test_batch_reranker.py tests/test_evaluate.py