### PR TITLE
dev の CI を通すため型診断エラーを修正

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -3,15 +3,16 @@ import json
 from typing import Callable
 
 from soramimi_phonetic_search_dataset import (
+    RankingFunctionOutput,
     evaluate_ranking_function,
     load_default_dataset,
     load_small_dataset,
+    rank_by_llm,
     rank_by_kanasim,
     rank_by_mora_editdistance,
     rank_by_phoneme_editdistance,
     rank_by_vowel_consonant_editdistance,
 )
-from soramimi_phonetic_search_dataset.reranker import rerank_by_llm
 
 
 def create_reranking_function(
@@ -23,7 +24,7 @@ def create_reranking_function(
     rerank_interval: int,
     topn: int,
     **base_rank_kwargs,
- ) -> Callable[[list[str], list[list[str]]], list[list[str]]]:
+ ) -> Callable[[list[str], list[list[str]]], RankingFunctionOutput]:
     """
     ベースのランキング関数とLLMによるリランクを組み合わせた関数を作成する
 
@@ -44,7 +45,7 @@ def create_reranking_function(
     def combined_rank_func(
         query_texts: list[str],
         wordlists: list[list[str]],
-    ) -> list[list[str]]:
+    ) -> RankingFunctionOutput:
         # ベースのランキングを実行
         base_ranked_wordlists = base_rank_func(query_texts, wordlists, **base_rank_kwargs)
 
@@ -56,12 +57,11 @@ def create_reranking_function(
         # topk_ranked_wordlists = [
         #    sorted(wordlist, key=lambda x: x[0]) for wordlist in topk_ranked_wordlists
         # ]
-        reranked_wordlists = rerank_by_llm(
+        reranked_wordlists = rank_by_llm(
             query_texts,
             topk_ranked_wordlists,
             topn=topn,
             model_name=rerank_model_name,
-            reasoning_effort=rerank_reasoning_effort,
             batch_size=rerank_batch_size,
             rerank_interval=rerank_interval,
         )

--- a/reproduce_leaderboard/methods/common/batch_reranker.py
+++ b/reproduce_leaderboard/methods/common/batch_reranker.py
@@ -27,7 +27,7 @@ def _build_rerank_metrics_metadata(
     token_cost: Any,
     discount_factor: float | None = None,
 ) -> dict[str, Any]:
-    metadata = {
+    metadata: dict[str, Any] = {
         "model_name": model_name,
         "token_usage": {
             "input_tokens": token_usage.input_tokens,

--- a/reproduce_leaderboard/methods/common/reranker.py
+++ b/reproduce_leaderboard/methods/common/reranker.py
@@ -23,6 +23,9 @@ OpenAIBatchRerankResult = _core_reasoning.OpenAIBatchRerankResult
 RerankedWordlist = _core_reasoning.RerankedWordlist
 ThoughtfulRerankedWordlist = _core_reasoning.ThoughtfulRerankedWordlist
 
+_last_token_usage = TokenUsage()
+_last_structured_outputs: list[dict[str, Any]] = []
+
 
 def transform_text_for_rerank(text: str, input_transform: str = "none") -> str:
     if input_transform == "none":
@@ -709,6 +712,7 @@ def retrieve_openai_batch_rerank_job(
     return OpenAIBatchRerankResult(
         reranked_wordlists=reranked_wordlists,
         structured_outputs=structured_outputs,
+        token_usage=token_usage,
         batch_id=state["batch_id"],
         batch_status=batch_status,
         execution_time=_get_batch_execution_time(batch),

--- a/src/soramimi_phonetic_search_dataset/evaluate.py
+++ b/src/soramimi_phonetic_search_dataset/evaluate.py
@@ -1,7 +1,7 @@
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, TypeAlias
+from typing import Any, Callable, TypeAlias, cast
 
 from soramimi_phonetic_search_dataset.dataset import load_default_dataset
 from soramimi_phonetic_search_dataset.schemas import (
@@ -55,7 +55,7 @@ def _normalize_ranking_output(
     dict[str, Any] | None,
 ]:
     if isinstance(ranking_output, list):
-        return ranking_output, None, None
+        return cast(list[list[str]], ranking_output), None, None
 
     return (
         ranking_output.ranked_wordlists,

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 from soramimi_phonetic_search_dataset import (
     rank_by_kanasim,
     rank_by_llm,
@@ -287,9 +289,14 @@ def test_rank_by_llm_aggregates_token_usage_across_batches(monkeypatch):
     )
 
     def fake_get_structured_outputs(**kwargs):
-        reranked = [{"reranked": [0]} for _ in kwargs["messages"]]
+        reranked: list[dict[str, Any]] = [
+            {"reranked": [0]} for _ in kwargs["messages"]
+        ]
         return llm_ranking.StructuredOutputsResult(
-            parsed_responses=reranked,
+            parsed_responses=cast(
+                list[llm_ranking.BaseModel | dict[str, Any]],
+                reranked,
+            ),
             structured_outputs=reranked,
             token_usage=next(token_usages),
         )


### PR DESCRIPTION
## 概要
- `ty` で落ちていた既存の型診断エラーを修正
- `examples/basic_usage.py` の import / return type を現行 API に合わせる
- reranker 系の型定義とテストの型注釈を整理する

## 確認
- `uv run ruff check .`
- `uv run ty check .`
- `uv run pytest -q`