### PR TITLE
fix: resolve release tag before publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Fetch Tags
       if: ${{ inputs.version == '' && inputs.recreate == false }}
@@ -46,6 +48,19 @@ jobs:
           args="$args -d"
         fi
         bash .github/scripts/update_version.sh $args
+
+    - name: Resolve release tag
+      id: release-tag
+      shell: bash
+      run: |
+        if release_tag=$(git describe --tags --exact-match HEAD 2>/dev/null); then
+          echo "Using release tag already checked out on HEAD: $release_tag"
+        else
+          release_tag=$(git describe --tags --abbrev=0)
+          echo "Checking out latest release tag: $release_tag"
+          git checkout "$release_tag"
+        fi
+        echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
     - name: Install uv
       uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Fetch Tags
       if: ${{ inputs.version == '' && inputs.recreate == false }}
@@ -46,6 +48,19 @@ jobs:
           args="$args -n"
         fi
         bash .github/scripts/update_version.sh $args
+
+    - name: Resolve release tag
+      id: release-tag
+      shell: bash
+      run: |
+        if release_tag=$(git describe --tags --exact-match HEAD 2>/dev/null); then
+          echo "Using release tag already checked out on HEAD: $release_tag"
+        else
+          release_tag=$(git describe --tags --abbrev=0)
+          echo "Checking out latest release tag: $release_tag"
+          git checkout "$release_tag"
+        fi
+        echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
     - name: Install uv
       uses: astral-sh/setup-uv@v8.1.0


### PR DESCRIPTION
## 概要
- PublishToPyPI / PublishToTestPyPI で checkout を full history 取得に変更
- publish 前に release tag を解決し、untagged な HEAD では最新タグを checkout して build
- local version (`dev+g...`) が PyPI に送られる経路を塞ぐ

## 確認
- uv run task lint
- uv run task format --check
- uv run task test
- 最新タグ `v0.0.20` を checkout した build で `0.0.20` の wheel / sdist が生成されること